### PR TITLE
Adapt display_firefly to new Firefly API and make py3-compatible DM-7321

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 config.log
 doc/*.tag
 doc/html
+doc/xml
 doc/doxygen.conf
 python/lsst/display/firefly/version.py
 tests/.tests

--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -1,2 +1,3 @@
-import pkgutil, lsstimport
+import pkgutil
+import lsstimport
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/display/__init__.py
+++ b/python/lsst/display/__init__.py
@@ -1,2 +1,3 @@
-import pkgutil, lsstimport
+import pkgutil
+import lsstimport
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/display/firefly/__init__.py
+++ b/python/lsst/display/firefly/__init__.py
@@ -1,7 +1,7 @@
-# 
+#
 # LSST Data Management System
 # Copyright 2008, 2009, 2010 LSST Corporation.
-# 
+#
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).
 #
@@ -9,14 +9,14 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
-# You should have received a copy of the LSST License Statement and 
-# the GNU General Public License along with this program.  If not, 
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 

--- a/python/lsst/display/firefly/__init__.py
+++ b/python/lsst/display/firefly/__init__.py
@@ -21,4 +21,4 @@
 #
 
 from .version import *
-from firefly import *
+from .firefly import *

--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -93,7 +93,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
                 _fireflyClient.launch_browser()
                 _fireflyClient.add_listener(self.__handleCallbacks)
             except Exception as e:
-                raise RuntimeError("Unable to connect to client: %s" % e)
+                raise RuntimeError("Unable to connect to client %s:%d: %s" % (host, port, e))
 
         self._isBuffered = False
         self._regions = []

--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -36,6 +36,7 @@ import lsst.afw.display.virtualDevice as virtualDevice
 import lsst.afw.display.ds9Regions as ds9Regions
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
+import lsst.log
 
 try:
     import firefly_client
@@ -66,19 +67,18 @@ class DisplayImpl(virtualDevice.DisplayImpl):
     def __handleCallbacks(event):
         if 'type' in event['data']:
             if event['data']['type'] == 'AREA_SELECT':
-                print('*************area select')
+                lsst.log.debug('*************area select')
                 pParams = {'URL': 'http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits',
                            'ColorTable': '9'}
                 plot_id = 3
                 global _fireflyClient
                 _fireflyClient.show_fits(fileOnServer=None, plot_id=plot_id, additionalParams=pParams)
 
-        print("RHL", event)
+        lsst.log.debug("RHL", event)
         return
         data = dict((_.split('=') for _ in event.get('data', {}).split('&')))
         if data.get('type') == "POINT":
-            print("Event Received: %s" % data.get('id'))
-            sys.stdout.flush()
+            lsst.log.debug("Event Received: %s" % data.get('id'))
 
     def __init__(self, display, verbose=False, host="localhost", port=8080, name="afw", *args, **kwargs):
         virtualDevice.DisplayImpl.__init__(self, display, verbose)

--- a/ups/display_firefly.table
+++ b/ups/display_firefly.table
@@ -1,4 +1,4 @@
 setupRequired(afw)
-setupRequired(firefly)
+setupRequired(python_future)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
The Firefly backend for afwDisplay requires the {{firefly_client}} module, installable via {{pip install firefly_client}}. A Firefly server must be accessible.
- Applied autopep8 and futurize per Python 3 porting guide
- Implement masks display
- Update Python API calls to new firefly_client
- Implement erase, scale, zoom pan
