### PR TITLE
DM-8171 drop extra argument from __init__

### DIFF
--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -78,7 +78,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
         if data.get('type') == "POINT":
             lsst.log.debug("Event Received: %s" % data.get('id'))
 
-    def __init__(self, display, verbose=False, host="localhost", port=8080, name="afw", *args, **kwargs):
+    def __init__(self, display, verbose=False, host="localhost", port=8080, name="afw"):
         virtualDevice.DisplayImpl.__init__(self, display, verbose)
 
         if self.verbose:


### PR DESCRIPTION
To make the changes to afw.display work in DM-8171, a small change to the __init__ is needed in the Firefly backend.