### PR TITLE
DM-12007 Add tests to display_firefly

### DIFF
--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,0 +1,2 @@
+from lsst.sconsUtils import scripts
+scripts.BasicSConscript.tests(pyList=[])

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,55 @@
+#
+# LSST Data Management System
+# Copyright 2016 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+"""Test for imports of display_firefly backend
+
+Note that interactive user tests are in afw/tests/test_display.py
+"""
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+import lsst.utils.tests
+import lsst.display.firefly
+import ws4py
+
+
+class InvalidHostTestCase1(lsst.utils.tests.TestCase):
+    """Test for invalid host (not a Firefly server)"""
+
+    def testConnect(self):
+        with self.assertRaises(ws4py.websocket.HandshakeError):
+            lsst.display.firefly.firefly_client.FireflyClient(
+                                    'google.com:80')
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
Add a minimal import test to the package. Note: interactive user tests for all backends are in afw/tests/test_display.py

- Added `tests/` subdirectory
- Added `tests/test_import.py` that imports the package, and attempts to connect to a nonexistent host to raise a `ws4py.websocket.HandshakeError`.
- Added `tests/SConscript` file as described in the developer's guide.
