### PR TITLE
DM-14732 Regions appear on subsequent afw Displays with Firefly backend

### DIFF
--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -125,7 +125,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
     def _getRegionLayerId(self):
         return "lsstRegions%s" % self.display.frame if self.display else "None"
 
-    def _clear_image(self):
+    def _clearImage(self):
         """Delete the current image in the Firefly viewer
         """
         self._client.dispatch_remote_action(channel=self._client.channel,
@@ -139,7 +139,6 @@ class DisplayImpl(virtualDevice.DisplayImpl):
             title = str(self.display.frame)
         if image:
             self._erase()
-            self._clear_image()
 
             with tempfile.NamedTemporaryFile() as fd:
                 displayLib.writeFitsImage(fd.name, image, wcs, title)
@@ -148,7 +147,11 @@ class DisplayImpl(virtualDevice.DisplayImpl):
                 self._fireflyFitsID = _fireflyClient.upload_data(fd, 'FITS')
 
             ret = _fireflyClient.show_fits(self._fireflyFitsID, plot_id=str(self.display.frame),
-                                           Title=title, MultiImageIdx=0)
+                                           Title=title, MultiImageIdx=0,
+                                           PredefinedOverlayIds=' ')
+            # Firefly's Javascript API requires a space for parameters; otherwise
+            # the parameter will be ignored
+
             if not ret["success"]:
                 raise RuntimeError("Display of image failed")
 

--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -125,6 +125,13 @@ class DisplayImpl(virtualDevice.DisplayImpl):
     def _getRegionLayerId(self):
         return "lsstRegions%s" % self.display.frame if self.display else "None"
 
+    def _clear_image(self):
+        """Delete the current image in the Firefly viewer
+        """
+        self._client.dispatch_remote_action(channel=self._client.channel,
+                                            action_type='ImagePlotCntlr.deletePlotView',
+                                            payload=dict(plotId=str(self.display.frame)))
+
     def _mtv(self, image, mask=None, wcs=None, title=""):
         """Display an Image and/or Mask on a Firefly display
         """
@@ -132,6 +139,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
             title = str(self.display.frame)
         if image:
             self._erase()
+            self._clear_image()
 
             with tempfile.NamedTemporaryFile() as fd:
                 displayLib.writeFitsImage(fd.name, image, wcs, title)


### PR DESCRIPTION
* Add a `_clearImage` method to the Firefly backend
* When using `show_fits`, clear the list of predefined overlays that are carried over to new image displays

The `_clearImage` method did not fix the issue of having regions overlays appear on new displays, but it is retained as a potentially useful method in the backend.