### PR TITLE
DM-15333 Apply pan and scale at time of image display in display_firefly

### DIFF
--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -162,6 +162,12 @@ class DisplayImpl(virtualDevice.DisplayImpl):
             if self._lastZoom:
                 extraParams['InitZoomLevel'] = self._lastZoom
                 extraParams['ZoomType'] = 'LEVEL'
+            if self._lastPan:
+                extraParams['InitialCenterPosition'] = '{0:.3f};{1:.3f};PIXEL'.format(
+                                                        self._lastPan[0],
+                                                        self._lastPan[1])
+            if self._lastStretch:
+                extraParams['RangeValues'] = self._lastStretch
 
             ret = _fireflyClient.show_fits(self._fireflyFitsID, plot_id=str(self.display.frame),
                                            **extraParams)
@@ -211,6 +217,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
 
         if self.verbose:
             print("Flushing %d regions" % len(self._regions))
+            print(self._regions)
 
         self._regionLayerId = self._getRegionLayerId()
         _fireflyClient.add_region_data(region_data=self._regions, plot_id=str(self.display.frame),
@@ -415,7 +422,9 @@ class DisplayImpl(virtualDevice.DisplayImpl):
         Parameters:
         -----------
         colc, rowc : `float`
-            column and row in units of pixels
+            column and row in units of pixels (zero-based convention,
+              with the xy0 already subtracted off)
         """
-        self._lastPan = [colc, rowc] # saved for future use in _mtv
+        self._lastPan = [colc+0.5, rowc+0.5] # saved for future use in _mtv
+        # Firefly's internal convention is first pixel is (0.5, 0.5)
         _fireflyClient.set_pan(plot_id=str(self.display.frame), x=colc, y=rowc)

--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -88,6 +88,9 @@ class DisplayImpl(virtualDevice.DisplayImpl):
 
         global _fireflyClient
         if not _fireflyClient:
+            import os
+            if ('html_file' not in kwargs) and ('FIREFLY_HTML' not in os.environ):
+                kwargs['html_file'] = 'slate.html'
             try:
                 if url is None:
                     _fireflyClient = firefly_client.FireflyClient(channel=name, **kwargs)


### PR DESCRIPTION
Modify the `display_firefly` backend to remember the results of scale (stretch) commands, and to apply scale and pan parameters when displaying an image with `lsst.afw.display.mtv`.

* Remember and apply the serialized RangeValues string that Firefly uses
* Correct pan command by 0.5 pixels to follow LSST convention
* Apply the remembered pan position when using `mtv`
* Make `'slate.html'` the default if it is not passed explicitly or if the environment variable `FIREFLY_HTML` is not defined. This is necessary for Firefly to show readout of LSST pixel convention.