### PR TITLE
DM-15438 display_firefly setMaskTransparency is backwards

### DIFF
--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -424,7 +424,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
                                                   action_type='ImagePlotCntlr.overlayPlotChangeAttributes',
                                                   payload={'plotId': str(self.display.frame),
                                                            'imageOverlayId': k,
-                                                           'attributes': {'opacity': transparency/100.},
+                                                           'attributes': {'opacity':1.0 - transparency/100.},
                                                            'doReplot': False})
 
     def _getMaskTransparency(self, maskName):


### PR DESCRIPTION
Compute opacity (what Firefly uses) properly from transparency, so that transparency=100 translates to opacity of 0.