### PR TITLE
DM-16451 Fix color parameter names for overlaying footprints

### DIFF
--- a/examples/HSC-Footprints.ipynb
+++ b/examples/HSC-Footprints.ipynb
@@ -253,7 +253,7 @@
    "outputs": [],
    "source": [
     "display1.overlayFootprints(catalogSubset, color='rgba(74,144,226,0.50)',\n",
-    "                           highlightColor='cyan', selectColor='orange',\n",
+    "                           highlightColor='yellow', selectColor='orange',\n",
     "                           style='outline', layerString='detection footprints ',\n",
     "                           titleString='catalog footprints ')"
    ]

--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -550,6 +550,6 @@ class DisplayImpl(virtualDevice.DisplayImpl):
                                         footprint_layer_id=layerString + str(self.display.frame),
                                         plot_id=str(self.display.frame),
                                         color=color,
-                                        highlight_color=highlightColor,
-                                        select_color=selectColor,
+                                        highlightColor=highlightColor,
+                                        selectColor=selectColor,
                                         style=style)


### PR DESCRIPTION
* Use the correct parameter names `highlightColor` and `selectColor` in the call to `firefly_client.FireflyClient.overlay_footprints`
* In the example notebook, change `highlightColor` to `'yellow'`