### PR TITLE
DM-16518 Write footprints table for Firefly viewer in binary2 format

### DIFF
--- a/python/lsst/display/firefly/footprints.py
+++ b/python/lsst/display/firefly/footprints.py
@@ -160,7 +160,12 @@ def createFootprintsTable(catalog, xy0=None, insertColumn=4):
                                'footprint_corner2_x;footprint_corner2_y;spans;peaks'))
     outTable.infos.append(Info(name='pixelsys', value='zero-based'))
     # Check whether the coordinates are included and are valid
-    if (('coord_ra' in inputColumnNames) and
+    if (('slot_Centroid_x' in inputColumnNames) and
+            ('slot_Centroid_y' in inputColumnNames) and
+            np.isfinite(outTable.array['slot_Centroid_x']).any() and
+            np.isfinite(outTable.array['slot_Centroid_y']).any()):
+        coord_column_string = 'slot_Centroid_x;slot_Centroid_y;ZERO_BASED'
+    elif (('coord_ra' in inputColumnNames) and
             ('coord_dec' in inputColumnNames) and
             np.isfinite(outTable.array['coord_ra']).any() and
             np.isfinite(outTable.array['coord_dec']).any()):


### PR DESCRIPTION
* Write the footprints table in binary2 format, making as many modifications as possible to the table in the form of an `astropy.table.Table` format
* Remove the code that changed the units of seconds, because the warning doesn't happen anymore. It appears to have been fixed in LSST Science Pipelines code.
* If available, use `slots_Centroid_x` and `slots_Centroid_y` for the footprint centers