### PR TITLE
DM-18667 Add support to display_firefly for obtaining and passing along an authorization token for Firefly

### DIFF
--- a/doc/lsst.display.firefly/defining-displays-lsp.rst
+++ b/doc/lsst.display.firefly/defining-displays-lsp.rst
@@ -59,7 +59,7 @@ This command is specific to the Firefly backend of the afwDisplay framework.
 Defining a Display to open a browser tab
 ========================================
 
-The first time that a Display object is instantiated in your Python or noteook
+The first time that a Display object is instantiated in your Python or notebook
 session, you can specify that a browser tab be opened. You will need to allow
 pop-ups for the science platform site.
 
@@ -83,6 +83,15 @@ a clickable link to the Firefly viewer.
 Click on the link to bring up a browser tab or window. Your browser or system
 settings determine whether the link brings up a tab, or a window.
 
+
+Authorizing a Display
+=====================
+
+When working inside the LSST Science Platform with default settings,
+authorization of the connection to the Firefly server will be handled
+automatically. If you encounter a need to pass a token for authorization,
+you can pass it to the first Display instance you create, with
+the ``token=`` keyword parameter.
 
 Embedding the Firefly viewer in a notebook
 ==========================================

--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -100,19 +100,27 @@ class DisplayImpl(virtualDevice.DisplayImpl):
                     url = os.environ['FIREFLY_URL']
                 else:
                     raise RuntimeError('Cannot determine url from environment; you must pass url')
+
+            token = kwargs.get('token',
+                               os.environ.get('ACCESS_TOKEN', None))
+
             try:
                 if start_tab:
                     if verbose:
                         print('Starting Jupyterlab client')
                     _fireflyClient = firefly_client.FireflyClient.make_lab_client(
                         start_tab=True, start_browser_tab=start_browser_tab,
-                        html_file=kwargs.get('html_file'), verbose=verbose)
+                        html_file=kwargs.get('html_file'), verbose=verbose,
+                        token=token)
+
                 else:
                     if verbose:
                         print('Starting vanilla client')
                     _fireflyClient = firefly_client.FireflyClient.make_client(
                         url=url, html_file=html_file, launch_browser=True,
-                        channel_override=name, verbose=verbose)
+                        channel_override=name, verbose=verbose,
+                        token=token)
+
             except (HandshakeError, gaierror) as e:
                 raise RuntimeError("Unable to connect to %s: %s" % (url or '', e))
 


### PR DESCRIPTION
* retrieve token from `Display` kwarg if provided; then from `ACCESS_TOKEN` environment variable
* pass token to `FireflyClient` factory methods
* add a section to the documentation explaining the `token=` kwarg