### PR TITLE
DM-28707: Revert "DEP remove eups firefly client"

### DIFF
--- a/ups/display_firefly.table
+++ b/ups/display_firefly.table
@@ -1,5 +1,6 @@
 setupRequired(afw)
 setupRequired(geom)
 setupRequired(log)
+setupRequired(firefly_client)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
This reverts commit 3ca47b9c77dbd9fe90169b5dc4b3911f70667a06. (#35)

The conda firefly_client behaves differently when given a non-firefly
URL. It seems to allow it and so the test no longer passes.