### PR TITLE
DM-30015: Update conf.py for documenteer 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ display for use with the back-end-agnostic `afw.display` interface:
 
 ```
 import lsst.afw.display as afwDisplay
-afwDisplay.setDefaultBackend(‘firefly’)
+afwDisplay.setDefaultBackend('firefly')
 afw_display = afwDisplay.Display(frame=1)
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Firefly is IPAC's toolkit for construction of astronomical data user interfaces.
 
 ## Pointers to more information
 
-* Full documentation is available at https://display-firefly.lsst.io/ .
+* Full documentation is available at https://pipelines.lsst.io/modules/lsst.display.firefly/ .
 * Within the Rubin Science Platform environment, suitable Firefly servers
   are provided by default, so that in many cases the user need not be aware
   of the identity or URL of the server.
@@ -35,7 +35,7 @@ managed via Conda and supplied via the `rubin-env` mechanism.
 ## Usage
 
 Usage is described in detail in 
-the [documentation](https://display-firefly.lsst.io/).
+the [documentation](https://pipelines.lsst.io/modules/lsst.display.firefly/).
 However, in many cases the following is sufficient to set up a Firefly
 display for use with the back-end-agnostic `afw.display` interface:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,13 +1,13 @@
-#!/usr/bin/env python
 """Sphinx configuration file for an LSST stack package.
-This configuration only affects single-package Sphinx documenation builds.
+This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.display.firefly
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='display_firefly',
-    version=lsst.display.firefly.version.__version__))
+project = "display_firefly"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 110
 ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W504
 exclude =
   bin,
-  doc,
+  doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,
   tests/.tests


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package). Also updates the documentation URL in the README.