### PR TITLE
tickets/DM-44832

### DIFF
--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -107,7 +107,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
                         print('Starting Jupyterlab client')
                     _fireflyClient = firefly_client.FireflyClient.make_lab_client(
                         start_tab=True, start_browser_tab=start_browser_tab,
-                        html_file=kwargs.get('html_file'), verbose=verbose,
+                        html_file=html_file, verbose=verbose,
                         token=token)
 
                 else:

--- a/python/lsst/display/firefly/firefly.py
+++ b/python/lsst/display/firefly/firefly.py
@@ -84,7 +84,7 @@ class DisplayImpl(virtualDevice.DisplayImpl):
             import os
             start_tab = None
             html_file = kwargs.get('html_file',
-                                   os.environ.get('FIREFLY_HTML', 'slate.html'))
+                                   os.environ.get('FIREFLY_HTML', ''))
             if url is None:
                 if (('fireflyLabExtension' in os.environ) and
                         ('fireflyURLLab' in os.environ)):


### PR DESCRIPTION
This has broken with the release of firefly_client>=3.0.0.

The root cause is that the default for the `html_file` used by the client should be defaulting to what we calculate on line 86, but instead we were pulling from the arguments again, which could be `None`.

The first commit fixes that to use the calculated value.

The second one changes it from `slate.html` to the empty string to give us the (newer) triview which is the new Firefly default, rather than the older slate.